### PR TITLE
AW9523 must have IO setup priority.

### DIFF
--- a/components/aw9523/aw9523.h
+++ b/components/aw9523/aw9523.h
@@ -28,7 +28,7 @@ namespace esphome
         public:
             AW9523Component() = default;
 
-            float get_setup_priority() const override { return setup_priority::HARDWARE; }
+            float get_setup_priority() const override { return setup_priority::IO; }
 
             void setup() override;
             void dump_config() override;


### PR DESCRIPTION
The AW9523 must be set up before its pins are configured so it must have an earlier setup priority than the GPIO switch and binary sensor components. Otherwise the pins get set up prematurely and the configuration gets reset when the AW9523 setup function runs.

Prior to this change, AW9523 had HARDWARE setup priority so it was ambiguous whether it would be set up before or after GPIO components which also have HARDWARE priority. Indeed, this happened in my configuration and it did not work correctly.