### PR TITLE
Allow input latching behavior to be configured

### DIFF
--- a/components/aw9523/__init__.py
+++ b/components/aw9523/__init__.py
@@ -12,6 +12,7 @@ from esphome.const import (
 )
 
 CONF_AW9523 = "aw9523"
+CONF_LATCH_INPUTS = "latch_inputs"
 
 DEPENDENCIES = ["i2c"]
 MULTI_CONF = True
@@ -26,6 +27,7 @@ CONFIG_SCHEMA = (
         {
             cv.Required(CONF_ID): cv.declare_id(AW9523Component),
             cv.Optional("divider", default=0): cv.int_range(min=0, max=3),
+            cv.Optional(CONF_LATCH_INPUTS, default=True): cv.boolean,
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -37,6 +39,7 @@ async def to_code(config):
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
     cg.add(var.set_divider(config["divider"]))
+    cg.add(var.set_latch_inputs(config[CONF_LATCH_INPUTS]))
     return var
 
 def validate_mode(value):

--- a/components/aw9523/aw9523.cpp
+++ b/components/aw9523/aw9523.cpp
@@ -53,7 +53,7 @@ namespace esphome
 
         void AW9523Component::loop()
         {
-            if (this->is_failed())
+            if (this->is_failed() || !this->latch_inputs_)
                 return;
 
             auto input0 = this->reg(AW9523_REG_INPUT0).get();
@@ -200,9 +200,24 @@ namespace esphome
 
         bool AW9523Component::digital_read(uint8_t pin)
         {
-            uint16_t value = (1 << pin);
-
-            return this->value_ & value;
+            if (this->latch_inputs_) {
+                uint16_t value = (1 << pin);
+                return this->value_ & value;
+            } else {
+                if (!this->is_failed()) {
+                    if (pin < 8)
+                    {
+                        uint8_t value = (1 << pin);
+                        return this->reg(AW9523_REG_INPUT0).get() & value;
+                    }
+                    else if (pin < 16)
+                    {
+                        uint8_t value = (1 << (pin - 8));
+                        return this->reg(AW9523_REG_INPUT1).get() & value;
+                    }
+                }
+                return false;
+            }
         }
 
     } // namespace aw9523

--- a/components/aw9523/aw9523.h
+++ b/components/aw9523/aw9523.h
@@ -38,6 +38,8 @@ namespace esphome
             void set_divider(uint8_t divider);
             uint8_t get_divider();
 
+            void set_latch_inputs(bool latch_inputs) { this->latch_inputs_ = latch_inputs; }
+
             float get_max_current();
 
             void led_driver(uint8_t pin);
@@ -50,6 +52,7 @@ namespace esphome
         private:
             uint16_t value_{};
             uint8_t divider_{};
+            bool latch_inputs_{};
         };
 
     } // namespace aw9523

--- a/esphome-aw9523.yaml
+++ b/esphome-aw9523.yaml
@@ -28,6 +28,7 @@ aw9523:
   - id: aw9523_1
     address: 0x58
     divider: 3
+    latch_inputs: true
 
 wifi:
   ssid: !secret wifi_ssid


### PR DESCRIPTION
Currently the component automatically latches digital inputs on each run of the event loop but that's not always needed.  If inputs aren't being accessed then it only serves to slow down the loop.  And in my case, I tried reading an input multiple times before returning to the event loop and was confused when it didn't report any transitions.

So I've added a flag to configure that behavior.  What do you think?